### PR TITLE
Add `seed` option for deterministic output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.0 - 2023-01-06
+
+* Adds new `seed` option.
+
 ## 1.2.1 - 2023-01-06
 
 * Fixes misspelling of `separator` in typings. Thanks to Andrei Gec for the correction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.3.0 - 2023-01-06
+## UNRELEASED - 2023-01-06
 
 * Adds new `seed` option.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Examples:
     console.log(randomWords({ exactly: 2 }));
     ['beside', 'between']
 
+    console.log(randomWords({ min: 2, max: 3, seed: 'my-seed' }));
+    console.log(randomWords({ min: 2, max: 3, seed: 'my-seed' }));
+    ['plenty', 'pure']
+    ['plenty', 'pure']
+
     console.log(randomWords({ exactly: 5, join: ' ' }))
     'army beautiful became if exactly'
     

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `random-words` generates random words for use as sample text. We use it to generate random blog posts when testing [Apostrophe](http://apostrophecms.org).
 
-Cryptographic-quality randomness is NOT the goal, as speed matters for generating sample text and security does not. `Math.random()` is used.
+Cryptographic-quality randomness is NOT the goal, as speed matters for generating sample text and security does not. As such, `Math.random()` is used in most cases. Alternatively, the [seedrandom](https://www.npmjs.com/package/seedrandom) package is used when the `seed` option is used.
 
 Installation:
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ Examples:
     ['beside', 'between']
 
     console.log(randomWords({ min: 2, max: 3, seed: 'my-seed' }));
-    console.log(randomWords({ min: 2, max: 3, seed: 'my-seed' }));
-    // using a seed yields the same random words
     ['plenty', 'pure']
+
+    // this call will yield exactly the same results as the last since the same `seed` was used and the other inputs are identical
+    console.log(randomWords({ min: 2, max: 3, seed: 'my-seed' }));
     ['plenty', 'pure']
 
     console.log(randomWords({ exactly: 5, join: ' ' }))

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 `random-words` generates random words for use as sample text. We use it to generate random blog posts when testing [Apostrophe](http://apostrophecms.org).
 
-Cryptographic-quality randomness is NOT the goal, as speed matters for generating sample text and security does not. As such, `Math.random()` is used in most cases. Alternatively, the [seedrandom](https://www.npmjs.com/package/seedrandom) package is used when the `seed` option is used.
+Cryptographic-quality randomness is NOT the goal, as speed matters for generating sample text and security does not. As such, `Math.random()` is used in most cases.
+
+The `seed` option can be used for situations that require deterministic output. When given the same `seed` with the same input, `randomWords()` will yield deterministic results, in regards to both actual word selection and the number of words returned (when using `min` and `max`). The underlying implementation of this option utilizes the [seedrandom](https://www.npmjs.com/package/seedrandom) package as a replacement for `Math.random()`.
 
 Installation:
 
@@ -28,6 +30,7 @@ Examples:
 
     console.log(randomWords({ min: 2, max: 3, seed: 'my-seed' }));
     console.log(randomWords({ min: 2, max: 3, seed: 'my-seed' }));
+    // using a seed yields the same random words
     ['plenty', 'pure']
     ['plenty', 'pure']
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ declare type WordsOptions = {
   wordsPerString?: number;
   separator?: string;
   formatter?: (word: string, index: number) => string;
+  seed?: string;
 };
 
 declare type JoinedWordsOptions = WordsOptions & { join: string; };

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var seedrandom = require('seedrandom');
+
 var wordList = [
   // Borrowed from xkcd password generator which borrowed it from wherever
   "ability","able","aboard","about","above","accept","accident","according",
@@ -247,6 +249,8 @@ var wordList = [
 ];
 
 function words(options) {
+  // initalize random number generator for words if options.seed is provided
+  const wordRNG = options?.seed ? new seedrandom(options.seed) : null;
 
   function word() {
     if (options && options.maxLength > 1) {
@@ -270,11 +274,18 @@ function words(options) {
   }
 
   function generateRandomWord() {
-    return wordList[randInt(wordList.length)];
+    return wordList[randWordInt(wordList.length)];
   }
 
+  // random int as ordained by Math.random()
   function randInt(lessThan) {
     return Math.floor(Math.random() * lessThan);
+  }
+
+  // random int as seeded by options.seed if applicable, or Math.random() otherwise
+  function randWordInt(lessThan) {
+    const rand = wordRNG ? wordRNG() : Math.random();
+    return Math.floor(rand * lessThan);
   }
 
   // No arguments = generate one word

--- a/index.js
+++ b/index.js
@@ -250,7 +250,7 @@ var wordList = [
 
 function words(options) {
   // initalize random number generator for words if options.seed is provided
-  const wordRNG = options?.seed ? new seedrandom(options.seed) : null;
+  const random = options?.seed ? new seedrandom(options.seed) : null;
 
   function word() {
     if (options && options.maxLength > 1) {
@@ -274,18 +274,13 @@ function words(options) {
   }
 
   function generateRandomWord() {
-    return wordList[randWordInt(wordList.length)];
-  }
-
-  // random int as ordained by Math.random()
-  function randInt(lessThan) {
-    return Math.floor(Math.random() * lessThan);
+    return wordList[randInt(wordList.length)];
   }
 
   // random int as seeded by options.seed if applicable, or Math.random() otherwise
-  function randWordInt(lessThan) {
-    const rand = wordRNG ? wordRNG() : Math.random();
-    return Math.floor(rand * lessThan);
+  function randInt(lessThan) {
+    const r = random ? random() : Math.random();
+    return Math.floor(r * lessThan);
   }
 
   // No arguments = generate one word

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "random-words",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Generate one or more common English words",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "random-words",
-  "version": "1.3.0",
+  "version": "1.2.1",
   "description": "Generate one or more common English words",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "license": "MIT",
   "devDependencies": {
     "mocha": "^9.1.3"
+  },
+  "dependencies": {
+    "seedrandom": "^3.0.5"
   }
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -76,5 +76,37 @@ describe('random-words', function () {
             assert.ok(word === word.toUpperCase(), 'word is formatted')
         });
     });
+    it('should return the same words if the same seed is used', function () {
+        const seed = 'seed1'
+        const exactly = 20;
+        const join = ' ';
+
+        var words = randomWords({ seed, exactly, join });
+        var words2 = randomWords({ seed, exactly, join });
+
+        // all words should be the same
+        assert.ok(words == words2, 'words are the same')
+    });
+    it('should return different words if no seeds are provided', function () {
+        const exactly = 20;
+        const join = ' ';
+
+        var words = randomWords({ exactly, join });
+        var words2 = randomWords({ exactly, join });
+
+        // with 1952 possible words, at least one word in 20 should be different
+        assert.ok(words != words2, 'words are different')
+    });
+    it('should return different words if different seeds are used', function () {
+        const exactly = 20;
+
+        var words = randomWords({ seed: 'seed1', exactly });
+        var words2 = randomWords({ seed: 'seed2', exactly });
+
+        // with these seeds, all words should be different
+        for (let i = 0; i < exactly; i++) {
+            assert.ok(words[i] != words2[i], 'words are different')
+        }
+    });
 });
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -81,18 +81,27 @@ describe('random-words', function () {
         const exactly = 20;
         const join = ' ';
 
-        var words = randomWords({ seed, exactly, join });
-        var words2 = randomWords({ seed, exactly, join });
+        const words = randomWords({ seed, exactly, join });
+        const words2 = randomWords({ seed, exactly, join });
 
-        // all words should be the same
         assert.ok(words == words2, 'words are the same')
+    });
+    it('should return the same number of words if the same seed is used', function () {
+        const seed = 'seed1'
+        const min = 1;
+        const max = 10;
+
+        const words = randomWords({ seed, min, max });
+        const words2 = randomWords({ seed, min, max });
+
+        assert.ok(words.length == words2.length, 'number of words is the same')
     });
     it('should return different words if no seeds are provided', function () {
         const exactly = 20;
         const join = ' ';
 
-        var words = randomWords({ exactly, join });
-        var words2 = randomWords({ exactly, join });
+        const words = randomWords({ exactly, join });
+        const words2 = randomWords({ exactly, join });
 
         // with 1952 possible words, at least one word in 20 should be different
         assert.ok(words != words2, 'words are different')
@@ -100,13 +109,23 @@ describe('random-words', function () {
     it('should return different words if different seeds are used', function () {
         const exactly = 20;
 
-        var words = randomWords({ seed: 'seed1', exactly });
-        var words2 = randomWords({ seed: 'seed2', exactly });
+        const words = randomWords({ seed: 'seed1', exactly });
+        const words2 = randomWords({ seed: 'seed2', exactly });
 
         // with these seeds, all words should be different
         for (let i = 0; i < exactly; i++) {
             assert.ok(words[i] != words2[i], 'words are different')
         }
+    });
+    it('should return different number of words if different seeds are used', function () {
+        const min = 1;
+        const max = 10;
+
+        const words = randomWords({ seed: 'seed1', min, max });
+        const words2 = randomWords({ seed: 'seed2', min, max });
+
+        // with these seeds, the number of words should 5 and 3
+        assert.ok(words.length != words2.length, 'number of words is different')
     });
 });
 


### PR DESCRIPTION
## Summary

This change adds deterministic behavior to `randomWords` via a new `seed` option. When a `seed` is provided in the form of a string, the randomness of the word generator will become predictable. This is implemented using the [seedrandom](https://www.npmjs.com/package/seedrandom) package that provides a seed-able pseudorandom number generator. The `seed` option results in a deterministic output from `randomWords`, in regards to both actual word output and the number of words when using `min` and `max`. When a `seed` is not provided, `Math.random()` is utilized as normal.

This features enables users to generate random words in a predictable manner, making it useful for cases such as:
- Creating the same randomized output for multiple users w/o storing the results.
- Writing test cases that require a predictable output.
- Anonymizing data with random words predictably (ex. "confidential-name" always becomes "spin-two")
- Regenerating randomized output at a later date for bug reports.

## What are the specific steps to test this change?

1. Run unit tests
2. Add some `console.log`'s to the test cases and play with the seeds to see their effect.

## What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [x] Related tests have been updated

## Other information 

Five new unit tests have been added to verify the integrity of this new feature:
- `should return the same words if the same seed is used` - verifies the same 20 words are generated when the same `seed` option is used (i.e. that seeding does work)
- `should return the same number of words if the same seed is used` - verifies the same number of words is generated in a given `min`/`max` range (i.e. that seeding does work)
- `should return different words if no seeds are provided` - verifies that at least one word in 20 is different when leaving `seed` undefined (i.e. that existing implementation is not broken)
- `should return different words if different seeds are used` - verifies that all 20 words are different when using 2 different `seed` options: "seed1" and "seed2" (i.e. that different seeds do have different effects)
- `should return different number of words if different seeds are used` - verifies that a different number of words is generated in a given `min`/`max` range when using 2 different `seed` options: "seed1" and "seed2" (i.e. that different seeds do have different effects)