### PR TITLE
Fixed return type of generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- Fixed return type of `generate` so that it is consistent with the possibility of returning a `string` rather than a `string[]`
+
 ## 2.0.0 - 2023-06-08
 
 This is a significant update that transforms this module into an ECMAScript module and changes the name of the exported function. For that reason, we have updated the major version number.

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,8 +12,8 @@ declare type GenerateOptions = {
 
 declare type JoinedWordsOptions = GenerateOptions & { join: string };
 
-declare function generate(count?: number): string[];
-declare function generate(options: GenerateOptions): string[];
+declare function generate(count?: number): string | string[];
+declare function generate(options: GenerateOptions): string | string[];
 declare function generate(options: JoinedWordsOptions): string;
 
 declare const wordsList: string[];


### PR DESCRIPTION
## Summary

The return type of `generate` was previously `string[]`; this is incorrect as `generate` may return either a `string` or `string[]` depending on the parameter (for example, when `options === undefined`, `string` is returned). So, revised so a union of the two is returned in the declaration.

## What are the specific steps to test this change?

Tested modifications on my own application that uses random-words [orrshalev/typist-suite](https://github.com/orrshalev/typist-suite), and verified `tsc` pass runs as expected. Since change is trivial I did not write any tests, but if that is desired I am happy to write them.

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [x] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
