### PR TITLE
fix: Correct TypeScript type definition for wordList

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ declare function generate(count?: number): string | string[];
 declare function generate(options: GenerateOptions): string | string[];
 declare function generate(options: JoinedWordsOptions): string;
 
-declare const wordsList: string[];
+declare const wordList: string[];
 
 declare type CountOptions = {
   minLength?: number;


### PR DESCRIPTION
![image](https://github.com/apostrophecms/random-words/assets/61752998/c8e57106-1859-4093-8a34-8cddd76c3691)
![image](https://github.com/apostrophecms/random-words/assets/61752998/18472c41-db0a-440f-a084-44f2e9a386c8)
