### PR TITLE
fix: Correct TypeScript type definition for wordList

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ declare function generate(count?: number): string | string[];
 declare function generate(options: GenerateOptions): string | string[];
 declare function generate(options: JoinedWordsOptions): string;
 
-declare const wordsList: string[];
+declare const wordList: string[];
 
 declare type CountOptions = {
   minLength?: number;


### PR DESCRIPTION
![image](https://github.com/apostrophecms/random-words/assets/61752998/a7c5f9af-a027-400a-973c-89b24fac96d3)
![image](https://github.com/apostrophecms/random-words/assets/61752998/92e5434b-c215-429d-a0a6-7475c758c8a5)
