### PR TITLE
fix: Separate TypeScript function overloads for generate function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,8 @@ declare type GenerateOptions = {
 
 declare type JoinedWordsOptions = GenerateOptions & { join: string };
 
-declare function generate(count?: number): string | string[];
+declare function generate(): string;
+declare function generate(count: number): string[];
 declare function generate(options: GenerateOptions): string | string[];
 declare function generate(options: JoinedWordsOptions): string;
 


### PR DESCRIPTION
This is a small change for TypeScript to infer the correct types automatically for the generate function. When using the generate function without any parameters vs with a number parameter the type is inferred the same (either a string OR string array) however when using them in practice:
- Calling the generate function with no parameters **always** returns a string (single word - not a string array)
- Calling the generate function with a number parameter **always** returns a string array

Current behaviour when using the correct types deduced from the JavaScript implementation:
<img width="637" alt="Screenshot 2024-09-29 at 8 36 01 pm" src="https://github.com/user-attachments/assets/31e55619-62c7-466d-af83-bea2bad078d2">

Behaviour after changes:
<img width="434" alt="Screenshot 2024-09-29 at 8 53 50 pm" src="https://github.com/user-attachments/assets/a1132068-22fb-4574-9df0-02b171193594">
<img width="562" alt="Screenshot 2024-09-29 at 8 54 30 pm" src="https://github.com/user-attachments/assets/0c50b8f4-ae3f-4459-a583-a14c243d1827">
